### PR TITLE
Correct cert pinning and add cert validation with pinning to the cli.

### DIFF
--- a/cli/nessie.go
+++ b/cli/nessie.go
@@ -16,15 +16,17 @@ func init() {
 	flag.StringVar(&apiURL, "api_url", "", "")
 	flag.StringVar(&username, "username", "", "Username to login with, in production read that from a file, do not set from the command line or it will end up in your history.")
 	flag.StringVar(&password, "password", "", "Password that matches the provided username, in production read that from a file, do not set from the command line or it will end up in your history.")
-	flag.StringList(&fingerprints, nil, "SPKI Fingerprints for the Nessus server using SHA-256 encoded in base64.")
+	flag.StringVar(&fingerprints, "fingerprints", "", "Comma-separated list of SPKI Fingerprints for the Nessus server using SHA-256 encoded in base64.")
 	flag.Parse()
 }
 
 func main() {
-	if len(*fingerprints) > 0 {
-		nessus, err := nessie.NewFingerprintedNessus(apiURL, *fingerprints)
+	var err error
+	var nessus nessie.Nessus
+	if len(fingerprints) > 0 {
+		nessus, err = nessie.NewFingerprintedNessus(apiURL, strings.Split(fingerprints, ","))
 	} else {
-		nessus, err := nessie.NewInsecureNessus(apiURL)
+		nessus, err = nessie.NewInsecureNessus(apiURL)
 	}
 	if err != nil {
 		panic(err)

--- a/cli/nessie.go
+++ b/cli/nessie.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var apiURL, username, password string
+var apiURL, username, password, fingerprints string
 
 func init() {
 	flag.StringVar(&apiURL, "api_url", "", "")

--- a/cli/nessie.go
+++ b/cli/nessie.go
@@ -16,11 +16,16 @@ func init() {
 	flag.StringVar(&apiURL, "api_url", "", "")
 	flag.StringVar(&username, "username", "", "Username to login with, in production read that from a file, do not set from the command line or it will end up in your history.")
 	flag.StringVar(&password, "password", "", "Password that matches the provided username, in production read that from a file, do not set from the command line or it will end up in your history.")
+	flag.StringList(&fingerprints, nil, "SPKI Fingerprints for the Nessus server using SHA-256 encoded in base64.")
 	flag.Parse()
 }
 
 func main() {
-	nessus, err := nessie.NewInsecureNessus(apiURL)
+	if len(*fingerprints) > 0 {
+		nessus, err := nessie.NewFingerprintedNessus(apiURL, *fingerprints)
+	} else {
+		nessus, err := nessie.NewInsecureNessus(apiURL)
+	}
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Cert pinning does not require cert validity date checks.
- Only check the server cert because this cert is authenticated with a
    proof-of-possession during the TLS handshake.
- Support multiple cert fingerprints so that server key rotation can be
    performed by running the nessie client with both the old and new
    fingerprints.