### PR TITLE
Configure scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here are the resources accessible via the official API and their current impleme
 - Scanners ✓
   - List ✓
 - Scans
-  - Configure
+  - Configure ✓
   - Create ✓
   - Delete ✓
   - Delete history

--- a/nessie_test.go
+++ b/nessie_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-func TestDoRequest(t *testing.T) {
+func TestRequest(t *testing.T) {
 	// Test structure to be serialized.
 	type payload struct {
 		A int `json:"a"`
@@ -66,7 +66,7 @@ func TestDoRequest(t *testing.T) {
 			},
 		}
 		n.SetVerbose(true)
-		resp, err := n.doRequest(tt.method, tt.resource, tt.sentPayload, tt.wantStatus)
+		resp, err := n.Request(tt.method, tt.resource, tt.sentPayload, tt.wantStatus)
 		if tt.wantError {
 			if err == nil {
 				t.Errorf("got no error, expected one (%+v)", tt)
@@ -74,7 +74,7 @@ func TestDoRequest(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			t.Errorf("error in doRequest: %v (%+v)", err, tt)
+			t.Errorf("error in Request: %v (%+v)", err, tt)
 			continue
 		}
 		if resp.StatusCode != tt.serverStatus {

--- a/resources.go
+++ b/resources.go
@@ -166,24 +166,41 @@ type Scanner struct {
 	Owner            string `json:"owner"`
 }
 
-// Scans resources.
-
+// Scan resource.
 type Scan struct {
-	ID                   int64  `json:"id"`
-	UUID                 string `json:"uuid"`
-	Name                 string `json:"name"`
-	Owner                string `json:"owner"`
-	FolderID             int64  `json:"folder_id"`
-	Read                 bool   `json:"read"`
-	Status               string `json:"status"`
-	Shared               bool   `json:"shared"`
-	UserPerms            int64  `json:"user_permissions"`
-	CreationDate         int64  `json:"creation_date"`
-	LastModificationDate int64  `json:"last_modification_date"`
-	Control              bool   `json:"control"`
-	StartTime            string `json:"starttime"`
-	TimeZone             string `json:"timezone"`
-	RRules               string `json:"rrules"`
+	ID                        int64       `json:"id"`
+	UUID                      string      `json:"uuid"`
+	Name                      string      `json:"name"`
+	Owner                     string      `json:"owner"`
+	Shared                    int         `json:"shared"`
+	UserPermissions           int64       `json:"user_permissions"`
+	CreationDate              int64       `json:"creation_date"`
+	LastModificationDate      int64       `json:"last_modification_date"`
+	StartTime                 string      `json:"starttime"`
+	TimeZone                  string      `json:"timezone"`
+	RRules                    string      `json:"rrules"`
+	ContainerID               int         `json:"container_id"`
+	Description               string      `json:"description"`
+	PolicyID                  int         `json:"policy_id"`
+	ScannerID                 int         `json:"scanner_id"`
+	Emails                    string      `json:"emails"`
+	AttachReport              int         `json:"attach_report"`
+	AttachedReportMaximumSize int         `json:"attached_report_maximum_size"`
+	AttachedReportType        interface{} `json:"attached_report_type"`
+	Sms                       interface{} `json:"sms"`
+	Enabled                   int         `json:"enabled"`
+	UseDashboard              int         `json:"use_dashboard"`
+	DashboardFile             interface{} `json:"dashboard_file"`
+	LiveResults               int         `json:"live_results"`
+	ScanTimeWindow            int         `json:"scan_time_window"`
+	CustomTargets             string      `json:"custom_targets"`
+	Migrated                  int         `json:"migrated"`
+	LastScheduledRun          string      `json:"last_scheduled_run"`
+	NotificationFilters       interface{} `json:"notification_filters"`
+	TagID                     int         `json:"tag_id"`
+	DefaultPermisssions       int         `json:"default_permisssions"`
+	OwnerID                   int         `json:"owner_id"`
+	Type                      string      `json:"type"`
 }
 
 type Host struct {


### PR DESCRIPTION
1. add a method to configure-scan
1. export `doReqest` as a public method `Request`, it's more convenient to use this SDK especially for those rarely used APIs with complicated parameter data models(such as `editor/{scan/policy}/{id}`)